### PR TITLE
.gitignore fix to keep CMake temporary files out of git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 *.gch
+src/CMake*
+src/cmake*
+src/Makefile


### PR DESCRIPTION
Something weird happens in compilation chain. 
All temporary CMake files appears to be in `src` folder. 
Here is temporary dirty fix, but rather it needs to be a proper fix